### PR TITLE
Change position of placeholder for in grid containers

### DIFF
--- a/src/utils/Sorter.js
+++ b/src/utils/Sorter.js
@@ -565,6 +565,11 @@ export default Backbone.View.extend({
       $parent.css('flex-direction') !== 'column'
     )
       return;
+    if (
+      $parent &&
+      $parent.css('display') == 'grid'
+    )
+      return;
     switch (style.position) {
       case 'static':
       case 'relative':


### PR DESCRIPTION
Elements inside a grid container were considered to be in-flow which makes the placholder unusable when 2 or more elements are on the same line. This change makes elements in a grid container not inline.